### PR TITLE
fix CrossEntropy gradient method.  During backprop assumes sigmoid is…

### DIFF
--- a/scratchnet/losses.py
+++ b/scratchnet/losses.py
@@ -5,4 +5,4 @@ class CrossEntropy(object):
         return -(T * np.log(y) + (1 - T) * np.log(1 - y)).mean()
 
     def gradient(self, y, T):
-        return (y - T) / y.shape[0]
+        return (y - T) / (y * (1 - y)) / y.shape[0]


### PR DESCRIPTION
… activation on final layer.  This results in sigmoid gradient being incorprated twice during backprop.  Hit 0.99 model score within 10000 based on the setup from README.md